### PR TITLE
Fix/ unnecessary reset view controller

### DIFF
--- a/Sources/InfiniteScrollViews/PagedInfiniteScrollView.swift
+++ b/Sources/InfiniteScrollViews/PagedInfiniteScrollView.swift
@@ -44,7 +44,7 @@ import SwiftUI
 /// - Content: a View.
 /// - ChangeIndex: A type of data that will be given to draw the views and that will be increased and drecreased. It could be for example an Int, a Date or whatever you want.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public struct PagedInfiniteScrollView<Content: View, ChangeIndex> {
+public struct PagedInfiniteScrollView<Content: View, ChangeIndex: Equatable> {
     
     /// Data that will be passed to draw the view and get its frame.
     public var changeIndex: Binding<ChangeIndex>
@@ -226,16 +226,17 @@ public struct PagedInfiniteScrollView<Content: View, ChangeIndex> {
     }
     
     public func updateUIViewController(_ uiViewController: UIPageViewController, context: Context) {
-        /// Check if the view should update and if it should then it will be.
-        guard let currentView = uiViewController.viewControllers?.first, let currentIndex = currentView.storedChangeIndex as? ChangeIndex else {
-            return
+        if currentIndex != changeIndex.wrappedValue {
+            /// Check if the view should update and if it should then it will be.
+            guard let currentView = uiViewController.viewControllers?.first, let currentIndex = currentView.storedChangeIndex as? ChangeIndex else {
+                return
+            }
+            
+            let shouldAnimate: (Bool, UIPageViewController.NavigationDirection) = shouldAnimateBetween(changeIndex.wrappedValue, currentIndex)
+            let initialViewController = UIHostingController(rootView: content(changeIndex.wrappedValue))
+            initialViewController.storedChangeIndex = changeIndex.wrappedValue
+            uiViewController.setViewControllers([initialViewController], direction: shouldAnimate.1, animated: shouldAnimate.0, completion: nil)
         }
-        
-        let shouldAnimate: (Bool, UIPageViewController.NavigationDirection) = shouldAnimateBetween(changeIndex.wrappedValue, currentIndex)
-        
-        let initialViewController = UIHostingController(rootView: content(changeIndex.wrappedValue))
-        initialViewController.storedChangeIndex = changeIndex.wrappedValue
-        uiViewController.setViewControllers([initialViewController], direction: shouldAnimate.1, animated: shouldAnimate.0, completion: nil)
     }
     
     #endif

--- a/Sources/InfiniteScrollViews/PagedInfiniteScrollView.swift
+++ b/Sources/InfiniteScrollViews/PagedInfiniteScrollView.swift
@@ -226,12 +226,12 @@ public struct PagedInfiniteScrollView<Content: View, ChangeIndex: Equatable> {
     }
     
     public func updateUIViewController(_ uiViewController: UIPageViewController, context: Context) {
+        /// Check if the view should update and if it should then it will be.
+        guard let currentView = uiViewController.viewControllers?.first, let currentIndex = currentView.storedChangeIndex as? ChangeIndex else {
+            return
+        }
+        
         if currentIndex != changeIndex.wrappedValue {
-            /// Check if the view should update and if it should then it will be.
-            guard let currentView = uiViewController.viewControllers?.first, let currentIndex = currentView.storedChangeIndex as? ChangeIndex else {
-                return
-            }
-            
             let shouldAnimate: (Bool, UIPageViewController.NavigationDirection) = shouldAnimateBetween(changeIndex.wrappedValue, currentIndex)
             let initialViewController = UIHostingController(rootView: content(changeIndex.wrappedValue))
             initialViewController.storedChangeIndex = changeIndex.wrappedValue


### PR DESCRIPTION
I have a CategoriesView that uses PagedInfiniteScrollView to display categories’ overall data based on a time period. However, when I scroll down a bit, open a category’s detail view, and then go back, my scrollview is reset. This Pull request fixes that issue.

https://github.com/user-attachments/assets/b7d4a9b5-7e45-49a1-82e4-aa30778483fe

Sometimes, it causes a crash in my application.

<img width="4634" height="2436" alt="CleanShot 2025-08-24 at 18 03 44@2x" src="https://github.com/user-attachments/assets/97bb7c81-5a5e-4bd0-bf3a-5dffdb294db3" />
